### PR TITLE
Add `--root-path` flag to specify named root group/dataset for inclusion in checks

### DIFF
--- a/src/chexus/__main__.py
+++ b/src/chexus/__main__.py
@@ -27,12 +27,15 @@ def main():
         help='Skip the validators that have missing dependecies',
     )
     parser.add_argument('--skip', '-S', action='append',
-                        help='Skip groups and datasets with name matching any provided SKIP', required=False)
+                        help='Skip top-level groups with name matching any provided SKIP', required=False)
+    parser.add_argument('--root', '-R', action='append',
+                        help='Root group(s) for checking', required=False)
     parser.add_argument('path', help='Input file')
     args = parser.parse_args()
     path = args.path
     ignore_missing = args.ignore_missing
     skip = args.skip
+    root = args.root
 
     has_scipp = False
     try:
@@ -51,7 +54,7 @@ def main():
     else:
         has_scipp = True
 
-    group = chexus.read_json(path, skip=skip) if _is_text_file(path) else chexus.read_hdf5(path, skip=skip)
+    group = chexus.read_json(path, skip=skip, root=root) if _is_text_file(path) else chexus.read_hdf5(path, skip=skip, root=root)
 
     validators = chexus.validators.base_validators(has_scipp=has_scipp)
     results = chexus.validate(group, validators=validators)

--- a/src/chexus/__main__.py
+++ b/src/chexus/__main__.py
@@ -26,10 +26,13 @@ def main():
         action='store_true',
         help='Skip the validators that have missing dependecies',
     )
+    parser.add_argument('--skip', '-S', action='append',
+                        help='Skip groups and datasets with name matching any provided SKIP', required=False)
     parser.add_argument('path', help='Input file')
     args = parser.parse_args()
     path = args.path
     ignore_missing = args.ignore_missing
+    skip = args.skip
 
     has_scipp = False
     try:
@@ -48,7 +51,7 @@ def main():
     else:
         has_scipp = True
 
-    group = chexus.read_json(path) if _is_text_file(path) else chexus.read_hdf5(path)
+    group = chexus.read_json(path, skip=skip) if _is_text_file(path) else chexus.read_hdf5(path, skip=skip)
 
     validators = chexus.validators.base_validators(has_scipp=has_scipp)
     results = chexus.validate(group, validators=validators)

--- a/src/chexus/hdf5.py
+++ b/src/chexus/hdf5.py
@@ -7,10 +7,10 @@ import h5py
 from .tree import Dataset, Group
 
 
-def read_hdf5(path: str) -> Group:
+def read_hdf5(path: str, skip=None) -> Group:
     """Read HDF5 file and return tree of datasets and groups"""
     with h5py.File(path, "r") as f:
-        return _read_group(f)
+        return _read_group(f, skip=skip)
 
 
 def _read_attrs(node: h5py.Dataset | h5py.Group) -> dict[str, Any]:
@@ -23,14 +23,16 @@ def _read_attrs(node: h5py.Dataset | h5py.Group) -> dict[str, Any]:
     return attrs
 
 
-def _read_group(group: h5py.File, parent: Group | None = None) -> Group:
+def _read_group(group: h5py.File | h5py.Group, parent: Group | None = None, skip: list[str] | None = None) -> Group:
     """Read HDF5 group"""
     grp = Group(name=group.name, attrs=_read_attrs(group), children={}, parent=parent)
     for name, value in group.items():
-        if isinstance(value, h5py.Dataset):
+        if skip is not None and name in skip:
+            pass
+        elif isinstance(value, h5py.Dataset):
             grp.children[name] = _read_dataset(value, parent=grp)
         elif isinstance(value, h5py.Group):
-            grp.children[name] = _read_group(value, parent=grp)
+            grp.children[name] = _read_group(value, parent=grp, skip=skip)
         else:
             raise ValueError(f"Unsupported type: {type(value)}")
     return grp

--- a/src/chexus/json.py
+++ b/src/chexus/json.py
@@ -8,7 +8,7 @@ import numpy as np
 from .tree import Dataset, Group
 
 
-def read_json(path: str, skip: list[str] | None = None) -> Group:
+def read_json(path: str, skip: list[str] | None = None, root: list[str] | None = None) -> Group:
     """
     Read JSON NeXus file and return tree of datasets and groups.
 
@@ -52,11 +52,23 @@ def read_json(path: str, skip: list[str] | None = None) -> Group:
         ]
     },
     """
+    if root is None:
+        root = []
+    if any('/' in r for r in root):
+        raise ValueError('JSON parsing can only filter root-level groups (no path separators allowed)')
+    if skip is None:
+        skip = []
     with open(path, "r") as f:
-        return _read_group(json.load(f), skip=skip)
+        top = json.load(f)
+        keys = list(top.keys())
+        if len(root):
+            keys = [k for k in keys if k in root]
+        if len(skip):
+            keys = [k for k in keys if k not in skip]
+        return _read_group({k: top[k] for k in keys})
 
 
-def _read_group(group: dict[str, Any], parent: Group | None = None, skip: list[str] | None = None) -> Group:
+def _read_group(group: dict[str, Any], parent: Group | None = None) -> Group:
     """Read JSON group"""
     name = group.get("name", '')
     if parent is not None:
@@ -67,9 +79,9 @@ def _read_group(group: dict[str, Any], parent: Group | None = None, skip: list[s
             continue
         module = child.get("module")
         if module is None:
-            if child["type"] == "group" and (skip is None or child["name"] not in skip):
-                grp.children[child["name"]] = _read_group(child, parent=grp, skip=skip)
-        elif module == "dataset" and (skip is None or child["config"]["name"] not in skip):
+            if child["type"] == "group":
+                grp.children[child["name"]] = _read_group(child, parent=grp)
+        elif module == "dataset":
             grp.children[child["config"]["name"]] = _read_dataset(child, parent=grp)
         elif module in ["f142", 'f144']:
             grp.children[child["config"]["source"]] = _read_source(child, parent=grp)


### PR DESCRIPTION
I have produced an HDF5 file from a McStas simulation that includes at its top-level _both_ a NeXus group `/entry` and a serialized-representation of the McStas instrument in a group `/mcstas`. 
Both are included in one file in order to maintain the provenance of the simulated data.

For clarity, a representative output of `h5ls -v` follows:
```
$ h5ls -v FILENAME.h5 
Opened "FILENAME.h5" with sec2 driver.
entry                    Group
    Attribute: NX_class scalar
        Type:      variable-length null-terminated UTF-8 string
    Location:  1:1136
    Links:     1
mcstas                   Group
    Attribute: mccode-antlr_version_data-type-name scalar
        Type:      variable-length null-terminated UTF-8 string
    Attribute: name scalar
        Type:      variable-length null-terminated UTF-8 string
    Attribute: source scalar
        Type:      variable-length null-terminated UTF-8 string
    Location:  1:18091416
    Links:     1
```

I would like to use `chexus` to verify the correctness of the `/entry` NeXus group, but since the `/mcstas` group _is not_ NeXus
1. the runtime of `chexus` is long
2. the output is swamped with notices about things that I know are not NeXus missing required NeXus features.

Since I know in advance that any group matching the name 'mcstas' _is not_ NeXus, I would like to inform `chexus` to skip any such-named group.

# Changes
This PR adds a command line flag `--skip` (or `-S`) that can be used one or more time to produce a list of names that `chexus` should skip.

The name of every encountered group and dataset is checked against the list of to-be-skipped names.
For consistency this is done when traversing JSON or HDF5.

For the file referenced above, the runtime improves from

```
$ time chexus FILENAME.h5
...
real	0m8,910s
user	0m8,315s
sys	0m1,087s
```
to
```
$ time chexus --skip mcstas FILENAME.h5
...
real	0m0,956s
user	0m0,935s
sys	0m0,726s
```

and the output is reduced by 50828 lines.

# Possible issues
If a user wanted to skip only a _specific_ subset of all, e.g., `mcstas` groups or datasets, this implementation would be insufficient. Such behavior could be enabled by matching full-path names (or regular expression matching against full path names) -- then `/mcstas` and, e.g., `/entry/instrument/some_component/mcstas` would not necessarily be matched by the same argument passed via `--skip`.