### PR TITLE
Add flag to allow returning bad exit code if validation fails

### DIFF
--- a/src/chexus/__init__.py
+++ b/src/chexus/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 
-# flake8: noqa
+# flake8: noqa E402
 import importlib.metadata
 
 try:
@@ -16,4 +16,20 @@ from .hdf5 import read_hdf5
 from .io import compute_checksum, make_fileinfo
 from .json import read_json
 from .tree import Dataset, Group, unroll_tree
-from .validate import Validator, Violation, report, validate
+from .validate import Validator, Violation, has_violations, report, validate
+
+__all__ = [
+    "Dataset",
+    "Group",
+    "Validator",
+    "Violation",
+    "compute_checksum",
+    "has_violations",
+    "make_fileinfo",
+    "read_hdf5",
+    "read_json",
+    "report",
+    "unroll_tree",
+    "validate",
+    "validators",
+]

--- a/src/chexus/__main__.py
+++ b/src/chexus/__main__.py
@@ -26,6 +26,12 @@ def main():
         action='store_true',
         help='Skip the validators that have missing dependecies',
     )
+    parser.add_argument(
+        '-e',
+        '--exception',
+        action='store_true',
+        help='Raise an exception if validation fails',
+    )
     parser.add_argument('path', help='Input file')
     args = parser.parse_args()
     path = args.path
@@ -56,6 +62,8 @@ def main():
     print(chexus.make_fileinfo(path))
     if args.checksums:
         print(chexus.compute_checksum(path))
+    if args.exception and chexus.has_violations(results):
+        raise ValueError('Validation failed')
 
 
 if __name__ == '__main__':

--- a/src/chexus/__main__.py
+++ b/src/chexus/__main__.py
@@ -26,11 +26,11 @@ def main():
         action='store_true',
         help='Skip the validators that have missing dependecies',
     )
+    # Add argument to return bad exit code if validation fails
     parser.add_argument(
-        '-e',
-        '--exception',
+        '--exit-on-fail',
         action='store_true',
-        help='Raise an exception if validation fails',
+        help='Return a non-zero exit code if validation fails',
     )
     parser.add_argument('path', help='Input file')
     args = parser.parse_args()
@@ -62,8 +62,9 @@ def main():
     print(chexus.make_fileinfo(path))
     if args.checksums:
         print(chexus.compute_checksum(path))
-    if args.exception and chexus.has_violations(results):
-        raise ValueError('Validation failed')
+    if args.exit_on_fail and chexus.has_violations(results):
+        print('Validation has failed')
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/src/chexus/validate.py
+++ b/src/chexus/validate.py
@@ -81,3 +81,7 @@ def report(results: dict[type, ValidationResult]) -> str:
     summary += '\n'
     summary += f"Total: {total_violations}/{total_checks}"
     return f'{details}\n\n{summary}'
+
+
+def has_violations(results: dict[type, ValidationResult]) -> bool:
+    return any(result.fails for result in results.values())


### PR DESCRIPTION
This will be useful for using `chexus` in CI to validate nexus files.