### PR TITLE
Check for value in NXlog

### DIFF
--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -310,6 +310,27 @@ class depends_on_missing(Validator):
             return Violation(node.name)
 
 
+class NXlog_has_value(Validator):
+    def __init__(self) -> None:
+        super().__init__(
+            "NXlog_has_value",
+            "NXlogs must have a value field except for top_dead_center",
+        )
+
+    def applies_to(self, node: Dataset | Group) -> bool:
+        return isinstance(node, Group) and node.attrs.get('NX_class') == 'NXlog'
+
+    def validate(self, node: Dataset | Group) -> Violation | None:
+        if node.name == 'top_dead_center':
+            if 'value' in node.children:
+                return Violation(
+                    node.name, 'top_dead_center logs must not have a value'
+                )
+        else:
+            if 'value' not in node.children:
+                return Violation(node.name, 'NXlog must have a value')
+
+
 def base_validators(*, has_scipp=True):
     validators = [
         depends_on_missing(),
@@ -324,6 +345,7 @@ def base_validators(*, has_scipp=True):
         transformation_depends_on_missing(),
         transformation_offset_units_missing(),
         units_invalid(),
+        NXlog_has_value(),
     ]
     if has_scipp:
         validators += [

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -378,3 +378,61 @@ def test_NXdisk_chopper_units_log(units: str, good: bool):
     else:
         assert isinstance(result, chexus.Violation)
         assert result.name == 'x'
+
+
+def test_NXlog_has_value():
+    good = chexus.Group(
+        name='x',
+        parent=None,
+        attrs={'NX_class': 'NXlog'},
+        children={},
+    )
+    good.children['time'] = chexus.Dataset(
+        name='x/time', value=3.0, shape=None, dtype=int, parent=good
+    )
+    good.children['value'] = chexus.Dataset(
+        name='x/value', value=1.0, shape=None, dtype=float, parent=good
+    )
+    assert chexus.validators.NXlog_has_value().validate(good) is None
+
+    bad = chexus.Group(
+        name='x',
+        parent=None,
+        attrs={'NX_class': 'NXlog'},
+        children={},
+    )
+    bad.children['time'] = chexus.Dataset(
+        name='x/time', value=3.0, shape=None, dtype=int, parent=good
+    )
+    result = chexus.validators.float_dataset_units_missing().validate(bad)
+    assert isinstance(result, chexus.Violation)
+    assert result.name == 'x'
+
+
+def test_NXlog_top_dead_center_has_no_value():
+    good = chexus.Group(
+        name='top_dead_center',
+        parent=None,
+        attrs={'NX_class': 'NXlog'},
+        children={},
+    )
+    good.children['time'] = chexus.Dataset(
+        name='top_dead_center/time', value=3.0, shape=None, dtype=int, parent=good
+    )
+    assert chexus.validators.NXlog_has_value().validate(good) is None
+
+    bad = chexus.Group(
+        name='top_dead_center',
+        parent=None,
+        attrs={'NX_class': 'NXlog'},
+        children={},
+    )
+    bad.children['time'] = chexus.Dataset(
+        name='top_dead_center/time', value=3.0, shape=None, dtype=int, parent=good
+    )
+    bad.children['value'] = chexus.Dataset(
+        name='top_dead_center/value', value=1.0, shape=None, dtype=float, parent=bad
+    )
+    result = chexus.validators.float_dataset_units_missing().validate(bad)
+    assert isinstance(result, chexus.Violation)
+    assert result.name == 'top_dead_center'


### PR DESCRIPTION
Related to https://github.com/scipp/scippnexus/issues/237 and #28. This checks that NXlogs contain a `value` child. This will always be the case at ESS, except for `top_dead_center` which will never have a value. (Unless ECDC decide to change their encoding which we would then have to adapt to in Scipp).