### PR TITLE
feat: add validator for verifying uniqueness of detector_numbers

### DIFF
--- a/src/chexus/__main__.py
+++ b/src/chexus/__main__.py
@@ -62,7 +62,11 @@ def main():
     else:
         has_scipp = True
 
-    group = chexus.read_json(path) if _is_text_file(path) else chexus.read_hdf5(path)
+    if _is_text_file(path):
+        group = chexus.read_json(path)
+    else:
+        reader = chexus.read_hdf5(path)
+        group = next(reader)
 
     validators = chexus.validators.base_validators(has_scipp=has_scipp)
 

--- a/src/chexus/__main__.py
+++ b/src/chexus/__main__.py
@@ -65,6 +65,7 @@ def main():
     if _is_text_file(path):
         group = chexus.read_json(path)
     else:
+        # File is closed when 'reader' goes out of scope
         reader = chexus.read_hdf5(path)
         group = next(reader)
 

--- a/src/chexus/__main__.py
+++ b/src/chexus/__main__.py
@@ -65,7 +65,8 @@ def main():
     if _is_text_file(path):
         group = chexus.read_json(path)
     else:
-        # File is closed when 'reader' goes out of scope
+        # File is closed when 'reader' goes out of scope.
+        # We need to keep it open for lazily loading values.
         reader = chexus.read_hdf5(path)
         group = next(reader)
 

--- a/src/chexus/hdf5.py
+++ b/src/chexus/hdf5.py
@@ -10,7 +10,7 @@ from .tree import Dataset, Group
 def read_hdf5(path: str, **kwargs) -> Group:
     """Read HDF5 file and return tree of datasets and groups"""
     with h5py.File(path, "r", **kwargs) as f:
-        return _read_group(f)
+        yield _read_group(f)
 
 
 def _read_attrs(node: h5py.Dataset | h5py.Group) -> dict[str, Any]:
@@ -44,9 +44,6 @@ def _read_dataset(dataset: h5py.Dataset, parent: Group) -> Dataset:
         dtype=dataset.dtype,
         attrs=_read_attrs(dataset),
         parent=parent,
+        dataset=dataset,
     )
-    try:
-        ds.value = dataset.asstr()[()]
-    except TypeError:
-        ds.value = dataset[()]
     return ds

--- a/src/chexus/hdf5.py
+++ b/src/chexus/hdf5.py
@@ -48,5 +48,5 @@ def _read_dataset(dataset: h5py.Dataset, parent: Group) -> Dataset:
     try:
         ds.value = dataset.asstr()[()]
     except TypeError:
-        pass
+        ds.value = dataset[()]
     return ds

--- a/src/chexus/hdf5.py
+++ b/src/chexus/hdf5.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from collections.abc import Iterator
 from typing import Any
 
 import h5py
@@ -7,7 +8,7 @@ import h5py
 from .tree import Dataset, Group
 
 
-def read_hdf5(path: str, **kwargs) -> Group:
+def read_hdf5(path: str, **kwargs) -> Iterator[Group]:
     """Read HDF5 file and return tree of datasets and groups"""
     with h5py.File(path, "r", **kwargs) as f:
         yield _read_group(f)

--- a/src/chexus/tree.py
+++ b/src/chexus/tree.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import h5py
 
+_no_value_set = object()
+
 
 @dataclass
 class Dataset:
@@ -17,20 +19,34 @@ class Dataset:
     dtype: str
     parent: Group
     attrs: dict[str, Any] = field(default_factory=dict)
-    value: Any | None = None
+    value: Any = _no_value_set
     dataset: h5py.Dataset | None = None
 
     @property
     def value(self) -> Any | None:  # noqa: F811
+        '''Returns the value of the dataset.
+        If the value attribute has been set by the user
+        that value is returned.
+        Otherwise, if the dataset has access to a h5py dataset
+        the value in that dataset will be returned.
+        If no value was set and the object has no h5py dataset
+        then None is returned.
+        '''
+        if self._value is not _no_value_set:
+            return self._value
         if self.dataset is not None:
+            # We don't want to cache the values
+            # by saving them in the _value attribute.
+            # The reason is that we don't want to
+            # run out of memory if the file is large.
             try:
                 return self.dataset.asstr()[()]
             except TypeError:
                 return self.dataset[()]
-        return self._value
+        return None
 
     @value.setter
-    def value(self, value: Any | None):
+    def value(self, value: Any):
         self._value = value
 
 

--- a/src/chexus/tree.py
+++ b/src/chexus/tree.py
@@ -19,7 +19,7 @@ class Dataset:
     dtype: str
     parent: Group
     attrs: dict[str, Any] = field(default_factory=dict)
-    value: Any = _no_value_set
+    value: Any | None = None
     dataset: h5py.Dataset | None = None
 
     @property
@@ -47,7 +47,14 @@ class Dataset:
 
     @value.setter
     def value(self, value: Any):
-        self._value = value
+        # When the dataclass object is created
+        # the setter will be called with
+        # an instance of type property.
+        # Set _value to uninitialized in that case.
+        if isinstance(value, property):
+            self._value = _no_value_set
+        else:
+            self._value = value
 
 
 @dataclass

--- a/src/chexus/tree.py
+++ b/src/chexus/tree.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+import h5py
+
 
 @dataclass
 class Dataset:
@@ -16,6 +18,20 @@ class Dataset:
     parent: Group
     attrs: dict[str, Any] = field(default_factory=dict)
     value: Any | None = None
+    dataset: h5py.Dataset | None = None
+
+    @property
+    def value(self) -> Any | None:  # noqa: F811
+        if self.dataset is not None:
+            try:
+                return self.dataset.asstr()[()]
+            except TypeError:
+                return self.dataset[()]
+        return self._value
+
+    @value.setter
+    def value(self, value: Any | None):
+        self._value = value
 
 
 @dataclass

--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -275,7 +275,7 @@ class detector_numbers_unique_in_all_detectors(Validator):
 
     def validate(self, node: Dataset | Group) -> Violation | None:
         detector_numbers = node.children['detector_number'].value
-        if not hasattr(detector_numbers, '__len__') or not len(detector_numbers):
+        if not hasattr(detector_numbers, '__len__'):
             return
         if np.isin(detector_numbers, self._seen_detector_numbers).any():
             return Violation(node.name)

--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -274,7 +274,7 @@ class detector_numbers_unique_in_all_detectors(Validator):
         )
 
     def validate(self, node: Dataset | Group) -> Violation | None:
-        detector_numbers = node.children['detector_number'].value
+        detector_numbers = np.asarray(node.children['detector_number'].value).ravel()
         if not hasattr(detector_numbers, '__len__'):
             return
         if np.isin(detector_numbers, self._seen_detector_numbers).any():

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -481,11 +481,16 @@ def test_NXlog_nested_top_dead_center_has_no_value():
     assert result.name == "chopper/top_dead_center"
 
 
-def test_duplicate_detector_number():
+@pytest.mark.parametrize('value', [(1, 2, 3), np.array([1, 2, 3]), [[0, 1], [2, 3]]])
+def test_duplicate_detector_number(value):
     det = chexus.Group(name="detector1", attrs={"NX_class": "NXdetector"})
     det.children = {
         'detector_number': chexus.Dataset(
-            name="detector_number", value=[1, 2, 3], shape=(3,), dtype=int, parent=det
+            name="detector_number",
+            value=value,
+            shape=np.array(value).shape,
+            dtype=int,
+            parent=det,
         )
     }
     det2 = chexus.Group(name="detector2", attrs={"NX_class": "NXdetector"})

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -479,3 +479,17 @@ def test_NXlog_nested_top_dead_center_has_no_value():
     result = chexus.validators.float_dataset_units_missing().validate(bad)
     assert isinstance(result, chexus.Violation)
     assert result.name == "chopper/top_dead_center"
+
+
+def test_duplicate_detector_number():
+    det = chexus.Group(name="detector1", attrs={"NX_class": "NXdetector"})
+    det.children = {
+        'detector_number': chexus.Dataset(
+            name="detector_number", value=[1, 2, 3], shape=(3,), dtype=int, parent=det
+        )
+    }
+    assert chexus.validators.detector_numbers_unique_in_all_detectors().applies_to(det)
+    validator = chexus.validators.detector_numbers_unique_in_all_detectors()
+    assert validator.validate(det) is None
+    # Second time the same detector numbers are seen, we expect a violation
+    assert validator.validate(det) is not None

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -488,8 +488,15 @@ def test_duplicate_detector_number():
             name="detector_number", value=[1, 2, 3], shape=(3,), dtype=int, parent=det
         )
     }
+    det2 = chexus.Group(name="detector2", attrs={"NX_class": "NXdetector"})
+    det2.children = {
+        'detector_number': chexus.Dataset(
+            name="detector_number", value=[4, 5, 6], shape=(3,), dtype=int, parent=det2
+        )
+    }
     assert chexus.validators.detector_numbers_unique_in_all_detectors().applies_to(det)
     validator = chexus.validators.detector_numbers_unique_in_all_detectors()
     assert validator.validate(det) is None
+    assert validator.validate(det2) is None
     # Second time the same detector numbers are seen, we expect a violation
     assert validator.validate(det) is not None


### PR DESCRIPTION
Fixes #35 

Note that this changes the way Chexus works in a significant way.
~This change makes Chexus read every dataset in the file and store them in memory while validating.

I think the better solution would be if the validators could decide to read data or not on a case by case basis, to limit the total amount read and to limit the max amount stored in memory.

But that would require some larger changes to the way chexus works.

* Should we do those changes now or wait until this actually becomes a problem in practice?
* Do we want those changes in this PR or in a separate PR?~ <- Outdated