### PR TITLE
feat: display what ids were missing from detector_numbers

### DIFF
--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -351,13 +351,9 @@ class event_id_subset_of_detector_number(Validator):
         event_ids = node.children['event_id'].value
         detector_numbers = node.parent.children['detector_number'].value
         if not np.isin(event_ids, detector_numbers).all():
-            show_max = 5
-            diff = np.setdiff1d(event_ids, detector_numbers)[:show_max]
+            diff = np.setdiff1d(event_ids, detector_numbers)
             return Violation(
-                node.name,
-                'event_id:s that are not in detector_number: '
-                f'{",".join(map(str, diff))}'
-                f'{",..." if len(diff) > show_max else ""}',
+                node.name, 'event_id:s that are not in detector_number: ' f'{diff}'
             )
 
 

--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -352,13 +352,12 @@ class event_id_subset_of_detector_number(Validator):
         detector_numbers = node.parent.children['detector_number'].value
         if not np.isin(event_ids, detector_numbers).all():
             show_max = 5
-            diff = ','.join(
-                map(str, np.setdiff1d(event_ids, detector_numbers)[:show_max])
-            )
+            diff = np.setdiff1d(event_ids, detector_numbers)[:show_max]
             return Violation(
                 node.name,
                 'event_id:s that are not in detector_number: '
-                f'{diff}{",..." if len(diff) > show_max else ""}',
+                f'{",".join(map(str, diff))}'
+                f'{",..." if len(diff) > show_max else ""}',
             )
 
 

--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -348,11 +348,18 @@ class event_id_subset_of_detector_number(Validator):
         )
 
     def validate(self, node: Dataset | Group) -> Violation | None:
-        if not np.isin(
-            node.children['event_id'].value,
-            node.parent.children['detector_number'].value,
-        ).all():
-            return Violation(node.name)
+        event_ids = node.children['event_id'].value
+        detector_numbers = node.parent.children['detector_number'].value
+        if not np.isin(event_ids, detector_numbers).all():
+            show_max = 5
+            diff = ','.join(
+                map(str, np.setdiff1d(event_ids, detector_numbers)[:show_max])
+            )
+            return Violation(
+                node.name,
+                'event_id:s that are not in detector_number: '
+                f'{diff}{",..." if len(diff) > show_max else ""}',
+            )
 
 
 class NXdetector_pixel_offsets_are_unambiguous(Validator):

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -654,12 +654,12 @@ def test_event_id_not_in_detector_number():
         )
         is None
     )
-    assert (
-        chexus.validators.event_id_subset_of_detector_number().validate(
-            det.children['data_bad']
-        )
-        is not None
+    violation = chexus.validators.event_id_subset_of_detector_number().validate(
+        det.children['data_bad']
     )
+    assert violation is not None
+    assert '4' in violation.description
+    assert '...' not in violation.description
 
 
 def test_NXdetector_pixel_offsets_are_unambiguous_1d_ids_1d_offset() -> None:

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -659,7 +659,6 @@ def test_event_id_not_in_detector_number():
     )
     assert violation is not None
     assert '4' in violation.description
-    assert '...' not in violation.description
 
 
 def test_NXdetector_pixel_offsets_are_unambiguous_1d_ids_1d_offset() -> None:


### PR DESCRIPTION
Adds a short list of missing ids to the violation error message.
This was asked about in the integration testing slack.