### PR TITLE
feat: verify type of event_index has 8 bytes

### DIFF
--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -469,6 +469,24 @@ class NXlog_has_value(Validator):
                 return Violation(node.name, "NXlog must have a value")
 
 
+class event_index_is_eight_bytes(Validator):
+    def __init__(self) -> None:
+        super().__init__(
+            "event_index_too_small", "event_index needs to be an 8 byte type"
+        )
+
+    def applies_to(self, node: Dataset | Group) -> bool:
+        return (
+            isinstance(node, Dataset)
+            and node.parent.attrs.get("NX_class") == "NXevent_data"
+            and node.name == 'event_index'
+        )
+
+    def validate(self, node: Dataset | Group) -> Violation | None:
+        if np.dtype(node.dtype).itemsize < 8:
+            return Violation(node.name, "event_index type too small")
+
+
 def base_validators(*, has_scipp=True):
     validators = [
         depends_on_missing(),

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -798,3 +798,27 @@ def test_NXdetector_pixel_offsets_are_unambiguous_2d_ids_allow_axis_attr() -> No
         chexus.validators.NXdetector_pixel_offsets_are_unambiguous().validate(det)
         is None
     )
+
+
+def test_event_index_is_eight_bytes() -> None:
+    parent = chexus.Group(name="event_data", attrs={"NX_class": "NXevent_data"})
+    good = chexus.Dataset(
+        name='event_index',
+        value=[1, 2, 3],
+        shape=(3,),
+        dtype='int64',
+        parent=parent,
+    )
+    bad = chexus.Dataset(
+        name='event_index',
+        value=[1, 2, 3],
+        shape=(3,),
+        dtype='int32',
+        parent=parent,
+    )
+    assert chexus.validators.event_index_is_eight_bytes().applies_to(good)
+    assert chexus.validators.event_index_is_eight_bytes().applies_to(bad)
+    assert chexus.validators.event_index_is_eight_bytes().validate(good) is None
+    assert isinstance(
+        chexus.validators.event_index_is_eight_bytes().validate(bad), chexus.Violation
+    )


### PR DESCRIPTION
`event_index` references positions in the `event_id` and `event_time_offset` arrays.
It's dtype has to be wide enough to contain integers that are the size of the event list.

We expect that some instrument might see more than 2^32=4B events during one experiment, therefore `event_index` must be 8 bytes.