### PR TITLE
fix: name is full path

### DIFF
--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -479,7 +479,7 @@ class event_index_is_eight_bytes(Validator):
         return (
             isinstance(node, Dataset)
             and node.parent.attrs.get("NX_class") == "NXevent_data"
-            and node.name == 'event_index'
+            and node.name.rpartition('/')[-1] == 'event_index'
         )
 
     def validate(self, node: Dataset | Group) -> Violation | None:

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -803,14 +803,14 @@ def test_NXdetector_pixel_offsets_are_unambiguous_2d_ids_allow_axis_attr() -> No
 def test_event_index_is_eight_bytes() -> None:
     parent = chexus.Group(name="event_data", attrs={"NX_class": "NXevent_data"})
     good = chexus.Dataset(
-        name='event_index',
+        name='event_data/event_index',
         value=[1, 2, 3],
         shape=(3,),
         dtype='int64',
         parent=parent,
     )
     bad = chexus.Dataset(
-        name='event_index',
+        name='event_data/event_index',
         value=[1, 2, 3],
         shape=(3,),
         dtype='int32',


### PR DESCRIPTION
`node.name` is the full path, I misunderstood that

I double checked that the validator is applied now on a real file.