### PR TITLE
Require NXevent_data has some "event" datasets 

### DIFF
--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -487,6 +487,27 @@ class event_index_is_eight_bytes(Validator):
             return Violation(node.name, "event_index type too small")
 
 
+class event_data_group_has_event_datasets(Validator):
+    '''Strictly speaking, all fields of NXevent_data are optional.
+    But in practice they are required so it is better to be
+    lightly opinionated about this.'''
+
+    def __init__(self) -> None:
+        super().__init__(
+            "event_data_has_event_datasets", "NXevent_data must have event dataset(s)"
+        )
+
+    def applies_to(self, node: Dataset | Group) -> bool:
+        return isinstance(node, Group) and node.attrs.get("NX_class") == "NXevent_data"
+
+    def validate(self, node: Group | Dataset) -> Violation | None:
+        for name in node.children:
+            if name in ('event_time_offset', 'event_id'):
+                break
+        else:
+            return Violation(node.name, "NXevent_data must have event dataset(s)")
+
+
 def base_validators(*, has_scipp=True):
     validators = [
         depends_on_missing(),
@@ -506,6 +527,7 @@ def base_validators(*, has_scipp=True):
         event_id_subset_of_detector_number(),
         NXdetector_pixel_offsets_are_unambiguous(),
         event_index_is_eight_bytes(),
+        event_data_group_has_event_datasets(),
     ]
     if has_scipp:
         validators += [

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -822,3 +822,59 @@ def test_event_index_is_eight_bytes() -> None:
     assert isinstance(
         chexus.validators.event_index_is_eight_bytes().validate(bad), chexus.Violation
     )
+
+
+@pytest.mark.parametrize('field', ['event_time_offset', 'event_id'])
+def test_event_data_has_event_datasets_good(field) -> None:
+    parent = chexus.Group(
+        name="event_data",
+        attrs={"NX_class": "NXevent_data"},
+    )
+    parent.children = {
+        field: chexus.Dataset(
+            name=f'event_data/{field}',
+            value=[1, 2, 3],
+            shape=(3,),
+            dtype='int32',
+            parent=parent,
+        )
+    }
+    assert chexus.validators.event_data_group_has_event_datasets().applies_to(parent)
+    assert (
+        chexus.validators.event_data_group_has_event_datasets().validate(parent) is None
+    )
+
+
+@pytest.mark.parametrize('field', ['event_time_something', 'event_ids'])
+def test_event_data_has_event_datasets_bad(field) -> None:
+    parent = chexus.Group(
+        name="event_data",
+        attrs={"NX_class": "NXevent_data"},
+    )
+    parent.children = {
+        field: chexus.Dataset(
+            name=f'event_data/{field}',
+            value=[1, 2, 3],
+            shape=(3,),
+            dtype='int32',
+            parent=parent,
+        )
+    }
+    assert chexus.validators.event_data_group_has_event_datasets().applies_to(parent)
+    assert isinstance(
+        chexus.validators.event_data_group_has_event_datasets().validate(parent),
+        chexus.Violation,
+    )
+
+
+def test_event_data_has_event_datasets_bad_empty() -> None:
+    parent = chexus.Group(
+        name="event_data",
+        attrs={"NX_class": "NXevent_data"},
+    )
+    parent.children = {}
+    assert chexus.validators.event_data_group_has_event_datasets().applies_to(parent)
+    assert isinstance(
+        chexus.validators.event_data_group_has_event_datasets().validate(parent),
+        chexus.Violation,
+    )


### PR DESCRIPTION
I saw this test failure:

https://scipp.github.io/nightly-dashboard/latest/nexusfiles-scipp_estia_load_raw_file_.html

The failing component seems to be a `NXevent_data` entry in the file that actually encodes a histogram monitor.

The added validator checks that any `NXevent_data` group has at least one of `event_time_offset` or `event_id` datasets.
This is strictly speaking not required by the Nexus standard, because both fields are optional, but I don't think there is a use case for having an event data group without `event_id` or `event_time_offset` so I think it makes sense to be "opinionated" here.