### PR TITLE
Transformations require depends on

### DIFF
--- a/src/chexus/validators.py
+++ b/src/chexus/validators.py
@@ -189,7 +189,11 @@ class non_numeric_dataset_has_units(Validator):
 
 
 def is_transformation(node: Dataset | Group) -> bool:
-    return "transformation_type" in node.attrs and "vector" in node.attrs
+    return (
+        node.attrs.get("NX_class") == "NXtransformation"
+        and "transformation_type" in node.attrs
+        and "vector" in node.attrs
+    )
 
 
 class transformation_offset_units_missing(Validator):

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -44,13 +44,21 @@ def test_depends_on_target_missing():
         attrs={"depends_on": "missing"},
     )
     group.children["transform"] = transform
+
     result = chexus.validators.depends_on_target_missing().validate(depends_on)
     # Still fails because 'transform' is not a transform
     assert isinstance(result, chexus.Violation)
     assert result.name == "x/depends_on"
     transform.attrs["transformation_type"] = "translation"
     transform.attrs["vector"] = [1.0, 0.0, 0.0]
+
+    result = chexus.validators.depends_on_target_missing().validate(depends_on)
+    # Still fails because 'transform' is not a NXtransformation
+    assert isinstance(result, chexus.Violation)
+    assert result.name == "x/depends_on"
+    transform.attrs["NX_class"] = "NXtransformation"
     assert chexus.validators.depends_on_target_missing().validate(depends_on) is None
+
     assert chexus.validators.depends_on_target_missing().applies_to(transform)
     result = chexus.validators.depends_on_target_missing().validate(transform)
     assert isinstance(result, chexus.Violation)
@@ -195,6 +203,7 @@ def test_transformation_depends_on_missing():
         dtype=float,
         parent=None,
         attrs={
+            "NX_class": "NXtransformation",
             "transformation_type": "translation",
             "vector": [1.0, 0.0, 0.0],
             "depends_on": ".",
@@ -209,6 +218,7 @@ def test_transformation_depends_on_missing():
         dtype=float,
         parent=None,
         attrs={
+            "NX_class": "NXtransformation",
             "transformation_type": "translation",
             "vector": [1.0, 0.0, 0.0],
         },
@@ -227,6 +237,7 @@ def test_transformation_offset_units_missing():
         dtype=float,
         parent=None,
         attrs={
+            "NX_class": "NXtransformation",
             "transformation_type": "translation",
             "vector": [1.0, 0.0, 0.0],
             "offset": 1.0,
@@ -244,6 +255,7 @@ def test_transformation_offset_units_missing():
         dtype=float,
         parent=None,
         attrs={
+            "NX_class": "NXtransformation",
             "transformation_type": "translation",
             "vector": [1.0, 0.0, 0.0],
             "offset": 1.0,
@@ -267,6 +279,7 @@ def test_transformation_offset_units_invalid_good(unit):
         dtype=float,
         parent=None,
         attrs={
+            "NX_class": "NXtransformation",
             "transformation_type": "translation",
             "vector": [1.0, 0.0, 0.0],
             "offset": 1.0,
@@ -291,6 +304,7 @@ def test_transformation_offset_units_invalid_bad(unit):
         dtype=float,
         parent=None,
         attrs={
+            "NX_class": "NXtransformation",
             "transformation_type": "translation",
             "vector": [1.0, 0.0, 0.0],
             "offset": 1.0,
@@ -320,6 +334,7 @@ def test_transformation_units_invalid(
             "name": "x",
             "parent": None,
             "attrs": {
+                "NX_class": "NXtransformation",
                 "transformation_type": transformation_type,
                 "vector": [1.0, 0.0, 0.0],
             },


### PR DESCRIPTION
I noticed that some targets of `depends_on` are not `NXtransformations`.
I don't think that is correct according to the nexus standard.

In any case, it causes problems in our transformation chain resolution because we expect that a target of a `depends_on` has a `depends_on` attribute and not a `depends_on` dataset, and non-`NXtransformation` components generally don't have a `depends_on` attribute, even if they might have a `depends_on` dataset.

Specifically, the detector component in the Estia nexus files depends on the `/entry/instrument/multiblade_detector/transformations/detector_rotation` entry which is a `NXpositioner` and does not have a `depends_on` attribute.

It does however have other attributes (`transformation_type` and `vector`) that indicates it was really intended to have been a `NXtransformation` but was mislabeled.

To catch this issue and similar I'm adding a requirement that any target of a `depends_on` has to be a `NXtransformation`.

